### PR TITLE
removed forceDisableDonationPrompts checks, fixes #81

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,13 +8,13 @@ org.gradle.jvmargs=-Xmx1G
 # Mod Properties
     version_type=release
     revision=1
-    mod_version=1.7.1
+    mod_version=1.7.2
     maven_group=me.flashyreese.mods
     archives_base_name=reeses_sodium_options
 
 # Dependency
-    sodium_version=mc1.20.3-0.5.6
-    iris_version=1.5.2+1.19.4
+    sodium_version=mc1.20.4-0.5.8
+    iris_version=1.20.4-1.6.15
 
 #Fabric api
     fabric_version=0.95.1+1.20.4

--- a/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/SodiumVideoOptionsScreen.java
+++ b/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/SodiumVideoOptionsScreen.java
@@ -75,7 +75,7 @@ public class SodiumVideoOptionsScreen extends Screen implements ScreenPromptable
         var options = SodiumClientMod.options();
 
         // If the user has disabled the nags forcefully (by config), or has already seen the prompt, don't show it again.
-        if (options.notifications.forceDisableDonationPrompts || options.notifications.hasSeenDonationPrompt) {
+        if (options.notifications.hasSeenDonationPrompt) {
             return;
         }
 
@@ -166,13 +166,13 @@ public class SodiumVideoOptionsScreen extends Screen implements ScreenPromptable
         this.donateButton = new FlatButtonWidget(donateButtonDim, donationText, this::openDonationPage);
         this.hideDonateButton = new FlatButtonWidget(hideDonateButtonDim, Text.literal("x"), this::hideDonationButton);
 
-        if (SodiumClientMod.options().notifications.hasClearedDonationButton || SodiumClientMod.options().notifications.forceDisableDonationPrompts) {
+        if (SodiumClientMod.options().notifications.hasClearedDonationButton) {
             this.setDonationButtonVisibility(false);
         }
 
 
         Dim2i searchTextFieldDim;
-        if (SodiumClientMod.options().notifications.hasClearedDonationButton || SodiumClientMod.options().notifications.forceDisableDonationPrompts) {
+        if (SodiumClientMod.options().notifications.hasClearedDonationButton) {
             searchTextFieldDim = new Dim2i(tabFrameDim.x(), tabFrameDim.y() - 26, tabFrameDim.width(), 20);
         } else {
             searchTextFieldDim = new Dim2i(tabFrameDim.x(), tabFrameDim.y() - 26, tabFrameDim.width() - (tabFrameDim.getLimitX() - donateButtonDim.x()) - 2, 20);
@@ -185,7 +185,7 @@ public class SodiumVideoOptionsScreen extends Screen implements ScreenPromptable
             //int size = this.client.textRenderer.getWidth(Text.translatable(IrisApi.getInstance().getMainScreenLanguageKey()));
             int size = this.client.textRenderer.getWidth(Text.translatable(IrisCompat.getIrisShaderPacksScreenLanguageKey()));
             Dim2i shaderPackButtonDim;
-            if (!(SodiumClientMod.options().notifications.hasClearedDonationButton || SodiumClientMod.options().notifications.forceDisableDonationPrompts)) {
+            if (!(SodiumClientMod.options().notifications.hasClearedDonationButton)) {
                 shaderPackButtonDim = new Dim2i(donateButtonDim.x() - 12 - size, tabFrameDim.y() - 26, 10 + size, 20);
             } else {
                 shaderPackButtonDim = new Dim2i(tabFrameDim.getLimitX() - size - 10, tabFrameDim.y() - 26, 10 + size, 20);


### PR DESCRIPTION
Sodium made changes to its donation buttons in order to prevent 'certain mod packs from shafting' them.
https://github.com/CaffeineMC/sodium-fabric/commit/94794ce

Removed the checks related to these, no longer crashes.

 Fixes #81 , #80