### PR TITLE
Port fabric mod to Minecraft 1.21.9 & Sodium 0.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java")
-    id("fabric-loom") version ("1.10-SNAPSHOT") apply (false)
+    id("fabric-loom") version ("1.11-SNAPSHOT") apply (false)
 }
 
-val MINECRAFT_VERSION by extra { "1.21.6" }
-val NEOFORGE_VERSION by extra { "21.6.4-beta" }
-val FABRIC_LOADER_VERSION by extra { "0.16.14" }
-val FABRIC_API_VERSION by extra { "0.127.0+1.21.6" }
+val MINECRAFT_VERSION by extra { "1.21.9" }
+val NEOFORGE_VERSION by extra { "21.9.11-beta" }
+val FABRIC_LOADER_VERSION by extra { "0.17.2" }
+val FABRIC_API_VERSION by extra { "0.134.0+1.21.9" }
 
 // This value can be set to null to disable Parchment.
 val PARCHMENT_VERSION by extra { null }
@@ -14,8 +14,8 @@ val PARCHMENT_VERSION by extra { null }
 // https://semver.org/
 val MAVEN_GROUP by extra { "me.flashyreese.mods" }
 val ARCHIVE_NAME by extra { "reeses-sodium-options" }
-val MOD_VERSION by extra { "1.8.4" }
-val SODIUM_VERSION by extra { "mc1.21.6-0.6.13" }
+val MOD_VERSION by extra { "1.8.5" }
+val SODIUM_VERSION by extra { "mc1.21.9-0.7.0" }
 
 allprojects {
     apply(plugin = "java")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,7 +3,7 @@ import net.fabricmc.loom.task.AbstractRemapJarTask
 plugins {
     id("java")
     id("idea")
-    id("fabric-loom") version "1.10-SNAPSHOT"
+    id("fabric-loom") version "1.11-SNAPSHOT"
 }
 
 val MINECRAFT_VERSION: String by rootProject.extra

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/SodiumVideoOptionsScreen.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/SodiumVideoOptionsScreen.java
@@ -23,6 +23,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.options.VideoSettingsScreen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import org.jetbrains.annotations.NotNull;
@@ -332,27 +334,27 @@ public class SodiumVideoOptionsScreen extends Screen implements ScreenPromptable
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+    public boolean mouseClicked(MouseButtonEvent event, boolean repeated) {
         if (this.prompt != null) {
-            return this.prompt.mouseClicked(mouseX, mouseY, button);
+            return this.prompt.mouseClicked(event, repeated);
         }
 
-        return super.mouseClicked(mouseX, mouseY, button);
+        return super.mouseClicked(event, repeated);
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyEvent event) {
         if (this.prompt != null) {
-            return this.prompt.keyPressed(keyCode, scanCode, modifiers);
+            return this.prompt.keyPressed(event);
         }
 
-        if (keyCode == GLFW.GLFW_KEY_P && (modifiers & GLFW.GLFW_MOD_SHIFT) != 0 && !(this.searchTextField != null && this.searchTextField.isFocused())) {
+        if (event.key() == GLFW.GLFW_KEY_P && (event.modifiers() & GLFW.GLFW_MOD_SHIFT) != 0 && !(this.searchTextField != null && this.searchTextField.isFocused())) {
             Minecraft.getInstance().setScreen(new VideoSettingsScreen(this.prevScreen, Minecraft.getInstance(), Minecraft.getInstance().options));
 
             return true;
         }
 
-        return super.keyPressed(keyCode, scanCode, modifiers);
+        return super.keyPressed(event);
     }
 
     @Override

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/ScrollableFrame.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/ScrollableFrame.java
@@ -7,6 +7,7 @@ import net.caffeinemc.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.ComponentPath;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.navigation.FocusNavigationEvent;
+import net.minecraft.client.input.MouseButtonEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -159,18 +160,18 @@ public class ScrollableFrame extends AbstractFrame {
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        return super.mouseClicked(mouseX, mouseY, button) || (this.canScrollHorizontal && this.horizontalScrollBar.mouseClicked(mouseX, mouseY, button)) || (this.canScrollVertical && this.verticalScrollBar.mouseClicked(mouseX, mouseY, button));
+    public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
+        return super.mouseClicked(event, bl) || (this.canScrollHorizontal && this.horizontalScrollBar.mouseClicked(event, bl)) || (this.canScrollVertical && this.verticalScrollBar.mouseClicked(event, bl));
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
-        return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY) || (this.canScrollHorizontal && this.horizontalScrollBar.mouseDragged(mouseX, mouseY, button, deltaX, deltaY)) || (this.canScrollVertical && this.verticalScrollBar.mouseDragged(mouseX, mouseY, button, deltaX, deltaY));
+    public boolean mouseDragged(MouseButtonEvent event, double deltaX, double deltaY) {
+        return super.mouseDragged(event, deltaX, deltaY) || (this.canScrollHorizontal && this.horizontalScrollBar.mouseDragged(event, deltaX, deltaY)) || (this.canScrollVertical && this.verticalScrollBar.mouseDragged(event, deltaX, deltaY));
     }
 
     @Override
-    public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        return super.mouseReleased(mouseX, mouseY, button) || (this.canScrollHorizontal && this.horizontalScrollBar.mouseReleased(mouseX, mouseY, button)) || (this.canScrollVertical && this.verticalScrollBar.mouseReleased(mouseX, mouseY, button));
+    public boolean mouseReleased(MouseButtonEvent event) {
+        return super.mouseReleased(event) || (this.canScrollHorizontal && this.horizontalScrollBar.mouseReleased(event)) || (this.canScrollVertical && this.verticalScrollBar.mouseReleased(event));
     }
     public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
         return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount) || (this.canScrollHorizontal && this.horizontalScrollBar.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)) || (this.canScrollVertical && this.verticalScrollBar.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount));

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/components/ScrollBarComponent.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/components/ScrollBarComponent.java
@@ -4,6 +4,8 @@ import net.caffeinemc.mods.sodium.client.gui.widgets.AbstractWidget;
 import net.caffeinemc.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.util.Mth;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
@@ -66,15 +68,15 @@ public class ScrollBarComponent extends AbstractWidget {
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (this.scrollBarArea.containsCursor(mouseX, mouseY)) {
-            if (this.scrollThumb.containsCursor(mouseX, mouseY)) {
-                this.scrollThumbClickOffset = (int) (this.mode == ScrollDirection.VERTICAL ? mouseY - this.scrollThumb.getCenterY() : mouseX - this.scrollThumb.getCenterX());
+    public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
+        if (this.scrollBarArea.containsCursor(event.x(), event.y())) {
+            if (this.scrollThumb.containsCursor(event.x(), event.y())) {
+                this.scrollThumbClickOffset = (int) (this.mode == ScrollDirection.VERTICAL ? event.y() - this.scrollThumb.getCenterY() : event.x() - this.scrollThumb.getCenterX());
                 this.isDragging = true;
             } else {
                 int thumbLength = this.mode == ScrollDirection.VERTICAL ? this.scrollThumb.height() : this.scrollThumb.width();
                 int trackLength = this.mode == ScrollDirection.VERTICAL ? this.scrollBarArea.height() : this.scrollBarArea.width();
-                int value = (int) (((this.mode == ScrollDirection.VERTICAL ? mouseY - this.scrollBarArea.y() : mouseX - this.scrollBarArea.x()) - thumbLength / 2.0) * this.maxContentOffset / (trackLength - thumbLength));
+                int value = (int) (((this.mode == ScrollDirection.VERTICAL ? event.y() - this.scrollBarArea.y() : event.x() - this.scrollBarArea.x()) - thumbLength / 2.0) * this.maxContentOffset / (trackLength - thumbLength));
                 this.setOffset(value);
                 this.isDragging = false;
             }
@@ -85,19 +87,19 @@ public class ScrollBarComponent extends AbstractWidget {
     }
 
     @Override
-    public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        if (button == 0) {
+    public boolean mouseReleased(MouseButtonEvent event) {
+        if (event.button() == 0) {
             this.isDragging = false;
         }
         return false;
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+    public boolean mouseDragged(MouseButtonEvent event, double deltaX, double deltaY) {
         if (this.isDragging) {
             int thumbLength = this.mode == ScrollDirection.VERTICAL ? this.scrollThumb.height() : this.scrollThumb.width();
             int trackLength = this.mode == ScrollDirection.VERTICAL ? this.scrollBarArea.height() : this.scrollBarArea.width();
-            int value = (int) (((this.mode == ScrollDirection.VERTICAL ? mouseY : mouseX) - this.scrollThumbClickOffset - (this.mode == ScrollDirection.VERTICAL ? this.scrollBarArea.y() : this.scrollBarArea.x()) - thumbLength / 2.0) * this.maxContentOffset / (trackLength - thumbLength));
+            int value = (int) (((this.mode == ScrollDirection.VERTICAL ? event.y() : event.x()) - this.scrollThumbClickOffset - (this.mode == ScrollDirection.VERTICAL ? this.scrollBarArea.y() : this.scrollBarArea.x()) - thumbLength / 2.0) * this.maxContentOffset / (trackLength - thumbLength));
             this.setOffset(value);
             return true;
         }
@@ -129,12 +131,12 @@ public class ScrollBarComponent extends AbstractWidget {
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyEvent event) {
         if (!this.isFocused()) {
             return false;
         }
 
-        int newOffset = switch (keyCode) {
+        int newOffset = switch (event.key()) {
             case GLFW.GLFW_KEY_UP -> this.getOffset() - SCROLL_STEP;
             case GLFW.GLFW_KEY_DOWN -> this.getOffset() + SCROLL_STEP;
             case GLFW.GLFW_KEY_LEFT -> this.mode == ScrollDirection.HORIZONTAL ? this.getOffset() - SCROLL_STEP : this.getOffset();

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/components/SearchTextFieldComponent.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/components/SearchTextFieldComponent.java
@@ -14,7 +14,9 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.navigation.FocusNavigationEvent;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
-import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.CharacterEvent;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
@@ -129,12 +131,12 @@ public class SearchTextFieldComponent extends AbstractWidget {
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        int clickX = Mth.floor(mouseX) - this.dim.x() - 6;
+    public boolean mouseClicked(MouseButtonEvent event, boolean repeated) {
+        int clickX = Mth.floor(event.x()) - this.dim.x() - 6;
         String displayedText = this.font.plainSubstrByWidth(this.text.substring(this.firstCharacterIndex), this.getInnerWidth());
         this.setCursor(this.font.plainSubstrByWidth(displayedText, clickX).length() + this.firstCharacterIndex);
 
-        this.setFocused(this.dim.containsCursor(mouseX, mouseY));
+        this.setFocused(this.dim.containsCursor(event.x(), event.y()));
         this.pages.forEach(page -> page
                 .getOptions()
                 .stream()
@@ -234,7 +236,7 @@ public class SearchTextFieldComponent extends AbstractWidget {
     }
 
     private void erase(int offset) {
-        if (Screen.hasControlDown()) {
+        if (Minecraft.getInstance().hasControlDown()) {
             this.eraseWords(offset);
         } else {
             this.eraseCharacters(offset);
@@ -370,14 +372,14 @@ public class SearchTextFieldComponent extends AbstractWidget {
     }
 
     @Override
-    public boolean charTyped(char chr, int modifiers) {
+    public boolean charTyped(CharacterEvent characterEvent) {
         if (!this.isActive()) {
             return false;
         }
-        if (StringUtil.isAllowedChatCharacter(chr)) {
+        if (characterEvent.isAllowedChatCharacter()) {
             if (this.editable) {
                 this.lastSearch.set(this.text.trim());
-                this.write(Character.toString(chr));
+                this.write(characterEvent.codepointAsString());
                 this.lastSearchIndex.set(0);
             }
             return true;
@@ -385,8 +387,9 @@ public class SearchTextFieldComponent extends AbstractWidget {
         return false;
     }
 
+
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyEvent event) {
         this.pages.forEach(page -> page.getOptions()
                 .stream()
                 .filter(OptionExtended.class::isInstance)
@@ -396,21 +399,21 @@ public class SearchTextFieldComponent extends AbstractWidget {
         if (!this.isActive()) {
             return false;
         } else {
-            this.selecting = Screen.hasShiftDown();
-            if (Screen.isSelectAll(keyCode)) {
+            this.selecting = event.hasShiftDown();
+            if (event.isSelectAll()) {
                 this.setCursorToEnd();
                 this.setSelectionEnd(0);
                 return true;
-            } else if (Screen.isCopy(keyCode)) {
+            } else if (event.isCopy()) {
                 Minecraft.getInstance().keyboardHandler.setClipboard(this.getSelectedText());
                 return true;
-            } else if (Screen.isPaste(keyCode)) {
+            } else if (event.isPaste()) {
                 if (this.editable) {
                     this.write(Minecraft.getInstance().keyboardHandler.getClipboard());
                 }
 
                 return true;
-            } else if (Screen.isCut(keyCode)) {
+            } else if (event.isCut()) {
                 Minecraft.getInstance().keyboardHandler.setClipboard(this.getSelectedText());
                 if (this.editable) {
                     this.write("");
@@ -418,7 +421,7 @@ public class SearchTextFieldComponent extends AbstractWidget {
 
                 return true;
             } else {
-                switch (keyCode) {
+                switch (event.key()) {
                     case GLFW.GLFW_KEY_ENTER -> {
                         if (this.editable) {
                             int count = 0;
@@ -458,7 +461,7 @@ public class SearchTextFieldComponent extends AbstractWidget {
                         if (this.editable) {
                             this.selecting = false;
                             this.erase(-1);
-                            this.selecting = Screen.hasShiftDown();
+                            this.selecting = event.hasShiftDown();
                         }
                         return true;
                     }
@@ -466,12 +469,12 @@ public class SearchTextFieldComponent extends AbstractWidget {
                         if (this.editable) {
                             this.selecting = false;
                             this.erase(1);
-                            this.selecting = Screen.hasShiftDown();
+                            this.selecting = event.hasShiftDown();
                         }
                         return true;
                     }
                     case GLFW.GLFW_KEY_RIGHT -> {
-                        if (Screen.hasControlDown()) {
+                        if (event.hasControlDown()) {
                             this.setCursor(this.getWordSkipPosition(1));
                         } else {
                             this.moveCursor(1);
@@ -481,7 +484,7 @@ public class SearchTextFieldComponent extends AbstractWidget {
                         return state;
                     }
                     case GLFW.GLFW_KEY_LEFT -> {
-                        if (Screen.hasControlDown()) {
+                        if (event.hasControlDown()) {
                             this.setCursor(this.getWordSkipPosition(-1));
                         } else {
                             this.moveCursor(-1);

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/tab/TabFrame.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/tab/TabFrame.java
@@ -9,6 +9,7 @@ import net.caffeinemc.mods.sodium.client.gui.widgets.AbstractWidget;
 import net.caffeinemc.mods.sodium.client.gui.widgets.FlatButtonWidget;
 import net.caffeinemc.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
@@ -154,18 +155,18 @@ public class TabFrame extends AbstractFrame {
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        return (this.dim.containsCursor(mouseX, mouseY) && super.mouseClicked(mouseX, mouseY, button)) || (this.tabSectionCanScroll && this.tabSectionScrollBar.mouseClicked(mouseX, mouseY, button));
+    public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
+        return (this.dim.containsCursor(event.x(), event.y()) && super.mouseClicked(event, bl)) || (this.tabSectionCanScroll && this.tabSectionScrollBar.mouseClicked(event, bl));
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
-        return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY) || (this.tabSectionCanScroll && this.tabSectionScrollBar.mouseDragged(mouseX, mouseY, button, deltaX, deltaY));
+    public boolean mouseDragged(MouseButtonEvent event, double deltaX, double deltaY) {
+        return super.mouseDragged(event, deltaX, deltaY) || (this.tabSectionCanScroll && this.tabSectionScrollBar.mouseDragged(event, deltaX, deltaY));
     }
 
     @Override
-    public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        return super.mouseReleased(mouseX, mouseY, button) || (this.tabSectionCanScroll && this.tabSectionScrollBar.mouseReleased(mouseX, mouseY, button));
+    public boolean mouseReleased(MouseButtonEvent event) {
+        return super.mouseReleased(event) || (this.tabSectionCanScroll && this.tabSectionScrollBar.mouseReleased(event));
     }
 
     @Override

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/mixin/sodium/MixinCyclingControlElement.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/mixin/sodium/MixinCyclingControlElement.java
@@ -3,6 +3,7 @@ package me.flashyreese.mods.reeses_sodium_options.mixin.sodium;
 import net.caffeinemc.mods.sodium.client.gui.options.Option;
 import net.caffeinemc.mods.sodium.client.gui.options.control.ControlElement;
 import net.caffeinemc.mods.sodium.client.util.Dim2i;
+import net.minecraft.client.input.MouseButtonEvent;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -22,9 +23,9 @@ public abstract class MixinCyclingControlElement<T extends Enum<T>> extends Cont
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (this.option.isAvailable() && this.dim.containsCursor(mouseX, mouseY) && (button == 0 || button == 1)) {
-            this.currentIndex = Math.floorMod(this.option.getValue().ordinal() + (button == 0 ? 1 : -1), this.allowedValues.length);
+    public boolean mouseClicked(MouseButtonEvent event, boolean bl) {
+        if (this.option.isAvailable() && this.dim.containsCursor(event.x(), event.y()) && (event.button() == 0 || event.button() == 1)) {
+            this.currentIndex = Math.floorMod(this.option.getValue().ordinal() + (event.button() == 0 ? 1 : -1), this.allowedValues.length);
             this.option.setValue(this.allowedValues[this.currentIndex]);
             this.playClickSound();
 

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/mixin/sodium/MixinSliderControlElement.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/mixin/sodium/MixinSliderControlElement.java
@@ -4,13 +4,12 @@ import me.flashyreese.mods.reeses_sodium_options.client.gui.SliderControlElement
 import net.caffeinemc.mods.sodium.client.gui.options.Option;
 import net.caffeinemc.mods.sodium.client.gui.options.control.ControlElement;
 import net.caffeinemc.mods.sodium.client.util.Dim2i;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.navigation.CommonInputs;
-import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.util.Mth;
-import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -73,20 +72,20 @@ public abstract class MixinSliderControlElement extends ControlElement<Integer> 
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyEvent event) {
         if (!isFocused()) return false;
 
-        if (CommonInputs.selected(keyCode)) {
+        if (event.isSelection()) {
             this.setEditMode(!this.isEditMode());
             return true;
         }
 
         if (this.isEditMode()) {
-            if (keyCode == GLFW.GLFW_KEY_LEFT) {
-                this.option.setValue(Mth.clamp(this.option.getValue() - interval, min, max));
+            if (event.isLeft()) {
+                this.option.setValue(Mth.clamp(this.option.getValue() - this.interval, this.min, this.max));
                 return true;
-            } else if (keyCode == GLFW.GLFW_KEY_RIGHT) {
-                this.option.setValue(Mth.clamp(this.option.getValue() + interval, min, max));
+            } else if (event.isRight()) {
+                this.option.setValue(Mth.clamp(this.option.getValue() + this.interval, this.min, this.max));
                 return true;
             }
         }
@@ -104,7 +103,7 @@ public abstract class MixinSliderControlElement extends ControlElement<Integer> 
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-        if (this.option.isAvailable() && this.sliderBounds.contains((int) mouseX, (int) mouseY) && Screen.hasShiftDown()) {
+        if (this.option.isAvailable() && this.sliderBounds.contains((int) mouseX, (int) mouseY) && Minecraft.getInstance().hasShiftDown()) {
             this.setValueFromMouseScroll(verticalAmount); // todo: horizontal separation
 
             return true;

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("idea")
-    id("fabric-loom") version ("1.10-SNAPSHOT")
+    id("fabric-loom") version ("1.11-SNAPSHOT")
 }
 
 val MINECRAFT_VERSION: String by rootProject.extra

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -39,8 +39,8 @@
     }
   },
   "depends": {
-    "minecraft": ">=1.21.6",
-    "sodium": ">=0.6.13"
+    "minecraft": ">=1.21.9",
+    "sodium": ">=0.7.0"
   },
   "breaks": {
     "iris": "<1.1.4",

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -19,14 +19,14 @@ Replaces Sodium's Options Screen
 [[dependencies.reeses_sodium_options]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.6,)"
+versionRange = "[1.21.9,)"
 ordering = "NONE"
 side = "CLIENT"
 
 [[dependencies.reeses_sodium_options]]
 modId = "sodium"
 type = "required"
-versionRange = "[0.6.13,)"
+versionRange = "[0.7.0,)"
 ordering = "NONE"
 side = "CLIENT"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,4 +10,4 @@ pluginManagement {
 
 include("common")
 include("fabric")
-include("neoforge")
+// include("neoforge")


### PR DESCRIPTION
Ported only the fabric version of the mod to Minecraft 1.21.9 & Sodium 0.7.0, as Neoforge itself is yet to support Minecraft 1.21.9.
I've made sure the functionality stays the same, the code needed minimal changes based on the changes made in the way Minecraft handles key events, mainly the change is `KeyEvent` and `MouseButtonEvent` replacing most scenarios where a key press or mouse button press is processed, and required minimal changes various function interfaces.