### PR TITLE
Don't crash the whole options screen on an unrecognized option type

### DIFF
--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/OptionRowFactory.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/OptionRowFactory.java
@@ -28,7 +28,7 @@ final class OptionRowFactory {
             case IntegerOption integerOption -> new IntegerSliderOptionRow(dim, this.theme, this.optionStateStore, integerOption);
             case EnumOption<?> enumOption -> new EnumOptionRow<>(dim, this.theme, this.optionStateStore, enumOption);
             case ExternalButtonOption externalButtonOption -> new ExternalButtonOptionRow(this.screen, dim, this.theme, this.optionStateStore, externalButtonOption);
-            default -> throw new IllegalArgumentException("Unsupported Sodium option type: " + option.getClass().getName());
+            default -> new UnsupportedOptionRow(dim, this.theme, this.optionStateStore, option);
         };
 
         this.registerOptionBounds(element, dim);

--- a/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/UnsupportedOptionRow.java
+++ b/common/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/UnsupportedOptionRow.java
@@ -1,0 +1,46 @@
+package me.flashyreese.mods.reeses_sodium_options.client.gui.frame.option;
+
+import me.flashyreese.mods.reeses_sodium_options.client.gui.layout.LayoutBounds;
+import me.flashyreese.mods.reeses_sodium_options.client.gui.state.OptionStateStore;
+import me.flashyreese.mods.reeses_sodium_options.client.gui.theme.GuiTheme;
+import net.caffeinemc.mods.sodium.client.config.structure.Option;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Fallback row for option types this addon doesn't recognize (e.g. a custom option type added by
+ * another mod that patches Sodium's config structure). Renders just the option's name with no
+ * interactive control, rather than throwing and taking down the whole video options screen -- one
+ * unrecognized option type shouldn't be able to crash every other mod's settings page.
+ */
+final class UnsupportedOptionRow extends AbstractOptionRow {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Reese's Sodium Options");
+    private static final Set<Class<?>> WARNED_TYPES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    UnsupportedOptionRow(LayoutBounds dim, GuiTheme theme, OptionStateStore optionStateStore, Option option) {
+        super(dim, theme, optionStateStore, option);
+
+        if (WARNED_TYPES.add(option.getClass())) {
+            LOGGER.warn("No option row registered for option type {}; rendering it as unsupported instead of crashing the options screen", option.getClass().getName());
+        }
+    }
+
+    @Override
+    protected int controlContentWidth() {
+        return 0;
+    }
+
+    @Override
+    protected void renderControl(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float delta) {
+    }
+
+    @Override
+    protected boolean activateControl() {
+        return false;
+    }
+}


### PR DESCRIPTION
This pull request improves the handling of unsupported or unknown option types in the options GUI. Instead of crashing when an unrecognized option type is encountered, the code now gracefully displays the option's name without an interactive control, and logs a warning. This ensures better compatibility with other mods that might introduce custom option types.

**Improved handling of unsupported option types:**

* Changed the default case in `OptionRowFactory` to use a new `UnsupportedOptionRow` instead of throwing an exception, preventing the options screen from crashing when an unknown option type is encountered.
* Added a new `UnsupportedOptionRow` class that displays the option's name without an interactive control and logs a warning the first time each unrecognized option type is seen.